### PR TITLE
Make credential fields sensitive and encrypt API Key

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -53,11 +53,12 @@
                         <field id="enable">1</field>
                     </depends>
                 </field>
-                <field id="api_key" translate="label" type="text" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="api_key" translate="label" type="obscure" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Sooqr API Key</label>
                     <depends>
                         <field id="enable">1</field>
                     </depends>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
                 <field id="statistics" translate="label" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Statistics</label>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -54,4 +54,12 @@
             <argument name="generalHelper" xsi:type="object">Magmodules\Sooqr\Helper\General</argument>
         </arguments>
     </type>
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+           <argument name="sensitive" xsi:type="array">
+              <item name="magmodules_sooqr/implementation/account_id" xsi:type="string">1</item>
+              <item name="magmodules_sooqr/implementation/api_key" xsi:type="string">1</item>
+           </argument>
+        </arguments>
+     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -56,10 +56,14 @@
     </type>
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
-           <argument name="sensitive" xsi:type="array">
-              <item name="magmodules_sooqr/implementation/account_id" xsi:type="string">1</item>
-              <item name="magmodules_sooqr/implementation/api_key" xsi:type="string">1</item>
-           </argument>
+            <argument name="sensitive" xsi:type="array">
+                <item name="magmodules_sooqr/implementation/account_id" xsi:type="string">1</item>
+                <item name="magmodules_sooqr/implementation/api_key" xsi:type="string">1</item>
+            </argument>
+            <argument name="environment" xsi:type="array">
+                <item name="magmodules_sooqr/feeds/results" xsi:type="string">1</item>
+            </argument>
         </arguments>
      </type>
-</config>
+ </config>
+


### PR DESCRIPTION
This PR marks a couple of fields as "sensitive" to avoid them being dumped into `app/etc/config.php` (a file that might be versioned).

#### Backwards Compatibility
No BC breaks under SemVer. Additionally:

* Nothing will change for existing installations until they re-save the Sooqr store settings page, at which point the `api_key` field will be encrypted into the database for a seamless upgrade experience that most existing installations will hardly even notice.

* I think the only flows that could "break" are those that (inappropriately) depend on these values being versioned in `app/etc/config.php`, but that's probably acceptable because it will lead to a more secure setup for those users.

With the above in mind, this could be released with just a revision bump (e.g. 1.1.5) along with simple upgrade instructions, e.g. `After upgrading, go to the Sooqr settings page and click on 'Save' without making any other changes.`