### PR TITLE
Release 2.5.2

### DIFF
--- a/.github/workflows/compile-and-phpstan.yml
+++ b/.github/workflows/compile-and-phpstan.yml
@@ -1,22 +1,25 @@
 name: Upgrade, Compile and PHPStan
-on: [ pull_request ]
+on: pull_request
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - PHP_VERSION: php74-fpm
-            MAGENTO_VERSION: 2.4.4-p13
+            MAGENTO_VERSION: 2.4.0
           - PHP_VERSION: php81-fpm
             MAGENTO_VERSION: 2.4.6-p4
           - PHP_VERSION: php83-fpm
             MAGENTO_VERSION: 2.4.7
           - PHP_VERSION: php84-fpm
-            MAGENTO_VERSION: 2.4.8-p2
+            MAGENTO_VERSION: 2.4.8
+          - PHP_VERSION: php84-fpm
+            MAGENTO_VERSION: 2.4.9
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Start Docker
         run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,13 @@
 name: Lint PHP files
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**/*.php'
+      - '**/*.phtml'
+  pull_request:
+    paths:
+      - '**/*.php'
+      - '**/*.phtml'
 
 jobs:
   php-74:
@@ -26,3 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: prestashop/github-action-php-lint/8.4@v2.3.1
+
+  php-85:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: prestashop/github-action-php-lint/8.5@master

--- a/Console/Command/CreateFeed.php
+++ b/Console/Command/CreateFeed.php
@@ -68,7 +68,7 @@ class CreateFeed extends Command
     /**
      * @inheritdoc
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setName(self::COMMAND_NAME);
         $this->setDescription('Generate feed file');
@@ -79,7 +79,7 @@ class CreateFeed extends Command
     /**
      * @inheritdoc
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
         foreach ($this->getStoreIds($input) as $storeId) {

--- a/Service/ProductData/Filter.php
+++ b/Service/ProductData/Filter.php
@@ -48,17 +48,16 @@ class Filter
         $entityIds = $this->filterVisibility($filter, $storeId);
         $entityIds = $this->filterStatus($entityIds, $filter['add_disabled_products'], $storeId);
 
-        if ($filter['restrict_by_category']) {
-            $websiteId = $storeId ? $this->getWebsiteId($storeId) : null;
-            $entityIds = $this->filterByWebsiteAndCategory(
-                $entityIds,
-                $websiteId,
-                $filter['category_restriction_behaviour'],
-                $filter['category']
-            );
-        }
-
-        return $entityIds;
+        return $this->filterByWebsiteAndCategory(
+            $entityIds,
+            $storeId
+                ? $this->getWebsiteId($storeId)
+                : null,
+            $filter['restrict_by_category']
+                ? $filter['category_restriction_behaviour']
+                : null,
+            $filter['category']
+        );
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magmodules/magento2-sooqr",
     "description": "Sooqr integration for Magento 2",
     "type": "magento2-module",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,7 +11,7 @@
         <sooqr_general>
             <general>
                 <enable>1</enable>
-                <version>v2.5.1</version>
+                <version>v2.5.2</version>
             </general>
             <credentials>
                 <environment>production</environment>


### PR DESCRIPTION
**Bugfixes:**
* Website filter no longer skipped when category restriction is disabled on multi-website setups (MM-SQR-002)
                                                                                                                                                                           
**Improvements:**
* Magento 2.4.9 and PHP 8.4 support
* Return types on CLI commands for Symfony 7 compatibility
